### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,9 @@ on:
       - develop
       - main
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/dspangenberg/twc-ui/security/code-scanning/1](https://github.com/dspangenberg/twc-ui/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function. Since the workflow does not perform any write operations, we can set `contents: read` as the permission. This ensures that the `GITHUB_TOKEN` has only read access to the repository contents.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs in the workflow. No additional dependencies or changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow configuration to explicitly set repository content read permissions for GitHub Actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->